### PR TITLE
Add support for Azure OpenAI, Palm, Replicate, Sagemaker (100+LLMs) - using litellm

### DIFF
--- a/examples/common.py
+++ b/examples/common.py
@@ -18,6 +18,7 @@ import functools
 import io
 import os
 from typing import List, NamedTuple, Tuple
+from litellm import completion
 
 import PIL.Image
 import replicate  # type: ignore
@@ -84,20 +85,14 @@ def chat_gpt(messages: List[Tuple[str, str]],
   Returns:
     The response from ChatGPT.
   """
-  json_dict = {
-    'model': model,
-    'messages': [
-      {'role': role, 'content': content}
-      for role, content in messages]}
-  r = requests.post(
-    url=CHAT_GPT_URL,
-    json=json_dict,
-    headers={'Authorization': 'Bearer ' + OPENAI_API_KEY.get(),
-             'Content-Type': 'application/json'})
   try:
-    return r.json()[
-      'choices'][0]['message']['content']
-  except IndexError:
-    raise ValueError('Unexpected response: %s' % r.json())
-  except KeyError:
-    raise ValueError('Unexpected response: %s' % r.json())
+    response = completion(
+      model=model,
+      messages=[
+        {'role': role, 'content': content}
+        for role, content in messages],
+        api_key=OPENAI_API_KEY.get()
+    )
+    return response['choices'][0]['message']['content']
+  except Exception as e:
+    raise Exception("Unexpected response: %s" % str(e))  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ dependencies = [
   "gradio",
   "numpy",
   "Pillow",
+  "litellm",
 ]
 description = "A framework for generative software."
 readme = "README.md"


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```