### PR TITLE
Add superclass context registration and convert stores to derived classes.

### DIFF
--- a/src/enact/references.py
+++ b/src/enact/references.py
@@ -326,13 +326,19 @@ class Store(contexts.Context):
     return ref.unpack(packed_resource)
 
 
-# pylint: disable=invalid-name
-def InMemoryStore() -> Store:
-  """Returns an in-memory store."""
-  return Store(backend=InMemoryBackend())
+@contexts.register_to_superclass(Store)
+class FileStore(Store):
+  """A file-based store."""
+
+  def __init__(self, root_dir: str):
+    """Initializes the store."""
+    super().__init__(backend=FileBackend(root_dir))
 
 
-# pylint: disable=invalid-name
-def FileStore(root_dir: str):
-  """Returns a file-based store."""
-  return Store(backend=FileBackend(root_dir))
+@contexts.register_to_superclass(Store)
+class InMemoryStore(Store):
+  """An in-memory store."""
+
+  def __init__(self):
+    """Initializes the store."""
+    super().__init__(backend=InMemoryBackend())


### PR DESCRIPTION
Adds a `register_to_superclass()` decorator that allows you to specify a registered enact context superclass to use for a derived class. 

Converts `FileStore` and `InMemoryStore` to derived classes registered with this decorator.  