### PR TITLE
Allow supported types to be committed directly.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "enact"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
   "numpy",
   "Pillow",

--- a/src/enact/resource_registry.py
+++ b/src/enact/resource_registry.py
@@ -188,6 +188,13 @@ class DictWrapper(FieldValueWrapper[dict]):
     target.clear()
     target.update(src)
 
+class ResourceTypeWrapper(FieldValueWrapper[type]):
+  """Wrapper for type-valued fields."""
+
+  @classmethod
+  def wrapped_type(cls) -> Type[type]:
+    return type
+
 
 FunctionWrapperT = TypeVar('FunctionWrapperT', bound='FunctionWrapper')
 MethodWrapperT = TypeVar('MethodWrapperT', bound='MethodWrapper')
@@ -293,6 +300,7 @@ class Registry:
     self.register(BytesWrapper)
     self.register(ListWrapper)
     self.register(DictWrapper)
+    self.register(ResourceTypeWrapper)
 
   def register(self, resource: Type[interfaces.ResourceBase]):
     """Registers the resource type."""


### PR DESCRIPTION
Enact already supports field types that are resource-type valued, e.g., `MyResource(value=MyResource)` and it supports field-types that are type valued if a wrapper for that type is defined, e.g., `MyResource(value=int)`.

When a field value is directly committed, e.g., `enact.commit(5)`, then the field value is wrapped in its corresponding resource. This was working for all field values, except types, and this PR adds the missing support.