### PR TITLE
Enable automatic semantic versioning and change packed type representation.

### DIFF
--- a/src/enact/__init__.py
+++ b/src/enact/__init__.py
@@ -81,6 +81,7 @@ from enact.resource_registry import RegistryError
 from enact.resource_registry import ResourceNotFound
 from enact.resource_registry import wrap
 from enact.resource_registry import unwrap
+from enact.resource_registry import deepcopy
 
 # Trigger registration of standard resource wrappers.
 import enact.type_wrappers

--- a/src/enact/acyclic.py
+++ b/src/enact/acyclic.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Agentic.AI Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Context to guard against cyclic datastructures."""
+
+from typing import List, Optional
+from enact import contexts
+
+
+class CycleDetected(Exception):
+  """Exception raised when a cycle is detected."""
+
+
+@contexts.register
+class AcyclicContext(contexts.Context):
+  """Helper to safeguard against cyclic data-structures."""
+
+  def __init__(self, obj):
+    """Initializes the context."""
+    super().__init__()
+    self.parent: Optional[AcyclicContext] = None
+    self.obj = obj
+
+  def enter(self):
+    """Check if the value is already on the stack."""
+    self.parent = AcyclicContext.get_current()
+    parent = self.parent
+    parents: List[AcyclicContext] = []
+    while parent is not None:
+      parents.append(parent)
+      if parent.obj is self.obj:
+        raise CycleDetected(
+          f'Resources may not have cyclic graph structure. '
+          f'Encountered cycle: '
+          f'{" -> ".join(str(p.obj) for p in parents)}')
+      parent = parent.parent

--- a/src/enact/digests.py
+++ b/src/enact/digests.py
@@ -54,15 +54,15 @@ def _digest(
                         interfaces.ResourceDict)):
     items: Iterable[Tuple[str, Value]]
     if isinstance(value, interfaces.ResourceBase):
-      res_type = type(value)
+      type_id = type(value).type_id()
       # Use alphabetical ordering.
       items = sorted(value.field_items(), key=lambda x: x[0])
     else:
       assert isinstance(value, interfaces.ResourceDict)
-      res_type = value.type
+      type_id = value.type_info.type_id()
       items = sorted(value.items(), key=lambda x: x[0])
     hash_obj.update(b'res[')
-    hash_obj.update(res_type.type_id().encode('utf-8'))
+    hash_obj.update(type_id.encode('utf-8'))
     for k, v in items:
       hash_obj.update(repr(k).encode('utf-8'))
       _digest(v, hash_obj, stack)

--- a/src/enact/function_wrappers.py
+++ b/src/enact/function_wrappers.py
@@ -268,6 +268,7 @@ def _create_function_wrapper(fun: Callable) -> (
     generated_type.__name__ = fun.__name__
     generated_type.__qualname__ = fun.__qualname__
   function_wrapper_type.method_wrapper().__name__ += '__method_wrapper'
+  function_wrapper_type.method_wrapper().__qualname__ += '__method_wrapper'
   return function_wrapper_type
 
 

--- a/src/enact/gradio/gradio.py
+++ b/src/enact/gradio/gradio.py
@@ -319,8 +319,7 @@ class JsonFieldWidget(EnactWidget):
     for field_name, value in zip(self._type.field_names(), component_values):
       json_val = json.loads(value)
       resource_dict[field_name] = self._serializer.from_json(json_val)
-    resource_type = resource_registry.wrap_type(self._type)
-    resource = resource_type.from_resource_dict(resource_dict)
+    resource = resource_registry.from_resource_dict(resource_dict)
     return resource_registry.unwrap(resource)
 
 

--- a/src/enact/invocations.py
+++ b/src/enact/invocations.py
@@ -306,7 +306,7 @@ class Invocation(Generic[I_contra, O_co], resources.Resource):
 
   def rewind(self, num_calls=1) -> 'Invocation[I_contra, O_co]':
     """Rewinds the invocation by the specified number of calls."""
-    invocation = self.deepcopy_resource()
+    invocation = resource_registry.deepcopy(self)
     with invocation.response.modify() as response:
       response.output = None
       for _ in range(num_calls):

--- a/src/enact/references.py
+++ b/src/enact/references.py
@@ -104,8 +104,8 @@ class Ref(Generic[R], interfaces.ResourceBase):
   def from_id(cls: Type[P], ref_id: str) -> P:
     """Returns a reference from a reference ID."""
     try:
-      return cls.from_resource_dict(
-        interfaces.ResourceDict(cls, **json.loads(ref_id)))
+      return cast(P, resource_registry.from_resource_dict(
+        interfaces.ResourceDict(cls, **json.loads(ref_id))))
     except json.JSONDecodeError as error:
       raise RefError(f'Invalid ref id: {ref_id}') from error
 
@@ -170,7 +170,9 @@ class Ref(Generic[R], interfaces.ResourceBase):
         f'Reference type mismatch: {packed_resource.ref} is not a {cls}.')
     cls.verify(packed_resource)
     return cast(
-      R, resource_registry.unwrap(packed_resource.data.to_resource()))
+      R,
+      resource_registry.unwrap(
+        resource_registry.from_resource_dict(packed_resource.data)))
 
   @classmethod
   def pack(cls, resource: R) -> PackedResource:

--- a/src/enact/resources.py
+++ b/src/enact/resources.py
@@ -65,7 +65,7 @@ class Resource(_Resource):
     """
     if not type(self) == type(other):  # pylint: disable=unidiomatic-typecheck
       raise TypeError(f'Cannot set_from {type(other)} into {type(self)}.')
-    copy = other.deepcopy_resource()
+    copy = resource_registry.deepcopy(other)
     for field in dataclasses.fields(self):
       self_field = getattr(self, field.name)
       target = getattr(other, field.name)

--- a/src/enact/serialization.py
+++ b/src/enact/serialization.py
@@ -69,7 +69,7 @@ class JsonSerializer(Serializer):
     """Converts a value to a JSON compatible value recursively."""
     if isinstance(value, interfaces.ResourceDict):
       result: Dict[str, Json] = {
-        self._escape('res'): (value.type.type_id())}
+        self._escape('res'): (value.type_info.type_id())}
       for k, v in value.items():
         if not isinstance(k, str):
           raise interfaces.FieldTypeError(

--- a/tests/register_enact_distribution.py
+++ b/tests/register_enact_distribution.py
@@ -1,0 +1,23 @@
+# Copyright 2023 Agentic.AI Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Import this from tests to register the tests module as a distribution."""
+
+import os
+
+import enact
+from enact import distribution_registry
+from enact import version
+
+distribution_registry.register_distribution(
+    f'{version.PKG_NAME}-tests', enact.__version__, os.path.dirname(__file__))

--- a/tests/test_resource_registry.py
+++ b/tests/test_resource_registry.py
@@ -15,6 +15,7 @@
 """Tests for the resource_registry module."""
 
 import dataclasses
+import os
 import types
 from typing import Any, List, Tuple, Type
 import unittest
@@ -22,8 +23,7 @@ import unittest
 import enact
 from enact import resource_registry
 from enact import version
-
-import register_enact_distribution  # pylint: disable=unused-import
+from enact import distribution_registry
 
 
 @enact.register
@@ -285,14 +285,19 @@ class RegistryTest(unittest.TestCase):
 
   def test_auto_assign_distribution_info(self):
     """Tests that type distribution info is auto-assigned on register"""
+    distribution_registry.register_distribution(
+      f'{version.DIST_NAME}-tests', version.__version__,
+      os.path.abspath(os.path.dirname(__file__)))
+
     class MyResource(enact.Resource):
       pass
+
     self.assertIsNone(MyResource.type_distribution_info())
     enact.register(MyResource)
     self.assertEqual(
       MyResource.type_distribution_info(),
       enact.DistributionInfo(
-        f'{version.PKG_NAME}-tests', version.__version__))
+        f'{version.DIST_NAME}-tests', version.__version__))
 
 
 if __name__ == 'main':

--- a/tests/test_resource_registry.py
+++ b/tests/test_resource_registry.py
@@ -21,6 +21,10 @@ import unittest
 
 import enact
 from enact import resource_registry
+from enact import version
+
+import register_enact_distribution  # pylint: disable=unused-import
+
 
 @enact.register
 @dataclasses.dataclass
@@ -272,6 +276,23 @@ class RegistryTest(unittest.TestCase):
     self.assertIsNot(copy[0], nest[0])
     self.assertIsNot(copy[1], nest[1])
     self.assertIsNot(copy[1]['a'], nest[1]['a'])
+
+  def test_enact_types_have_distribution_info(self):
+    """Tests that type distribution info is present for enact types."""
+    self.assertEqual(
+      resource_registry.IntWrapper.type_distribution_info(),
+      enact.DistributionInfo(version.DIST_NAME, version.__version__))
+
+  def test_auto_assign_distribution_info(self):
+    """Tests that type distribution info is auto-assigned on register"""
+    class MyResource(enact.Resource):
+      pass
+    self.assertIsNone(MyResource.type_distribution_info())
+    enact.register(MyResource)
+    self.assertEqual(
+      MyResource.type_distribution_info(),
+      enact.DistributionInfo(
+        f'{version.PKG_NAME}-tests', version.__version__))
 
 
 if __name__ == 'main':

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -20,8 +20,10 @@ from typing import Any, Type
 import unittest
 
 import enact
+from enact import resource_registry
 
 
+@enact.register
 @dataclasses.dataclass
 class SimpleResource(enact.Resource):
   a: Any
@@ -29,6 +31,7 @@ class SimpleResource(enact.Resource):
   c: Any
 
 
+@enact.register
 @dataclasses.dataclass
 class OtherSimpleResource(enact.Resource):
   a: Any
@@ -105,8 +108,8 @@ class ResourceTest(unittest.TestCase):
     as_dict = r.to_resource_dict()
     w_dict = as_dict['w']
     assert isinstance(w_dict, enact.ResourceDict)
-    self.assertEqual(w_dict.type, CustomWrapper)
-    rebuilt = as_dict.to_resource()
+    self.assertEqual(w_dict.type_info, CustomWrapper.type_info())
+    rebuilt = resource_registry.from_resource_dict(as_dict)
     self.assertEqual(r.w.x, rebuilt.w.x)
     self.assertEqual(r.i, rebuilt.i)
 
@@ -163,11 +166,11 @@ class RefTest(unittest.TestCase):
     with self.assertRaises(enact.FieldTypeError):
       enact.Ref.pack(a)
 
-  def test_deepy_copy_resource(self):
+  def test_deep_copy_resource(self):
     """Tests that the resource can be deep-copied."""
     a = SimpleResource(SimpleResource(1, 2, 3), [4, None],
                        {'a': 0.0, 'b': [True, False]})
-    b = a.deepcopy_resource()
+    b = enact.deepcopy(a)
     self.assertEqual(a, b)
     self.assertNotEqual(id(a), id(b))
     self.assertNotEqual(id(a.a), id(b.a))

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -56,7 +56,8 @@ class JsonSerializerTest(unittest.TestCase):
       r=enact.Ref('12314'), m={'a': ['test']}, l=[{'b': 1}, {'c': 2}],
       t=AllTypesResource)
     got = self.serializer.serialize(resource.to_resource_dict())
-    deserialized = self.serializer.deserialize(got).to_resource()
+    deserialized = resource_registry.from_resource_dict(
+      self.serializer.deserialize(got))
     self.assertEqual(deserialized, resource)
 
   def test_serialize_deserialize_fuzz(self):
@@ -65,5 +66,6 @@ class JsonSerializerTest(unittest.TestCase):
     for _ in range(100):
       resource = random_value.rand_resource()
       got = self.serializer.serialize(resource.to_resource_dict())
-      deserialized = self.serializer.deserialize(got).to_resource()
+      deserialized = resource_registry.from_resource_dict(
+        self.serializer.deserialize(got))
       self.assertEqual(deserialized, resource)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,8 +73,8 @@ class UtilsTest(unittest.TestCase):
       self.assertEqual(test_resource.value, 0)
       self.assertTrue(mock_getter.called)
 
-  def test_walk_resource_dict(self):
-    """Tests that walk resource dict works as expected."""
+  def test_walk_resource(self):
+    """Tests walk_resource and walk_resource_dict works as expected."""
     @enact.register
     @dataclasses.dataclass
     class TestResource(enact.Resource):
@@ -107,21 +107,27 @@ class UtilsTest(unittest.TestCase):
       [TestResource(1),
        TestResource(2),
        [1, 2, 3, 4],
-       Wrapped({'a': Wrapped(1)})]
+       Wrapped({'a': Wrapped(Wrapped)})]
     )
 
     result = list(
+      utils.walk_resource(test_instance))
+
+    dict_result = list(
       utils.walk_resource_dict(test_instance.to_resource_dict()))
 
     self.assertEqual(
       result,
       [
-        test_instance.to_resource_dict(),
-        TestResource(1).to_resource_dict(),
-        TestResource(2).to_resource_dict(),
-        Wrapper({'a': Wrapped(1)}).to_resource_dict(),
-        Wrapper(1).to_resource_dict()
+        test_instance,
+        TestResource(1),
+        TestResource(2),
+        Wrapper({'a': Wrapped(Wrapped)}),
+        Wrapper(Wrapped)
       ])
+    self.assertEqual(
+      [r.to_resource_dict() for r in result],
+      dict_result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This changes the type representation of a dictionary-packed resource to a named tuple that can be used to generate a key for the resource registry. Before, dictionary-packed resources would directly reference the type they represent, which meant that the ResourceDictionary format was only possible if the corresponding resource class was already loaded in.