### PR TITLE
Fix bug in type descriptor storage.

### DIFF
--- a/src/enact/__init__.py
+++ b/src/enact/__init__.py
@@ -82,7 +82,7 @@ from enact.registration import register
 
 from enact.resource_registry import Registry
 from enact.resource_registry import RegistryError
-from enact.resource_registry import ResourceNotFound
+from enact.resource_registry import UnregisteredResource
 from enact.resource_registry import wrap
 from enact.resource_registry import unwrap
 from enact.resource_registry import deepcopy

--- a/src/enact/references.py
+++ b/src/enact/references.py
@@ -104,6 +104,8 @@ class _PackHelper:
       self.type_keys.add(value.type_key())
     elif isinstance(value, type) and issubclass(value, interfaces.ResourceBase):
       self.type_keys.add(value.type_key())
+    else:
+      pass  # Ignore other field values.
 
 
 @resource_registry.register

--- a/src/enact/resource_registry.py
+++ b/src/enact/resource_registry.py
@@ -38,7 +38,7 @@ class RegistryError(Exception):
   """Raised when there is an error with the registry."""
 
 
-class ResourceNotFound(RegistryError):
+class UnregisteredResource(RegistryError):
   """Raised when a resource is not found."""
 
 
@@ -215,7 +215,9 @@ class Registry:
       type_id = type_id.type_id()
     resource_class = self._type_map.get(type_id)
     if not resource_class:
-      raise ResourceNotFound(f'No type registered for {type_id}')
+      raise UnregisteredResource(
+        f'No type registered for {type_id}.'
+        f'Did you forget to register the type with @enact.register?')
     return resource_class
 
   def _register_function_wrapper(self, wrapper_type: Type[FunctionWrapper]):

--- a/tests/test_invocations.py
+++ b/tests/test_invocations.py
@@ -232,6 +232,7 @@ class InvocationsTest(unittest.TestCase):
 
   def test_meta_invoke(self):
     """Tests that meta-invocations are tracked correctly."""
+    @enact.register
     @dataclasses.dataclass
     class MetaInvoke(enact.Invokable):
       invokable: enact.InvokableBase
@@ -250,6 +251,7 @@ class InvocationsTest(unittest.TestCase):
 
   def test_wrapped_resource(self):
     """Tests that exceptions are tracked as wrapped when enabled."""
+    @enact.register
     class PythonErrorOnInvoke(enact.Invokable):
       def call(self, unused_input: enact.ResourceBase):
         raise ValueError('foo')
@@ -264,11 +266,13 @@ class InvocationsTest(unittest.TestCase):
 
   def test_raise_native_error(self):
     """Tests that exceptions are raised in native format."""
+    @enact.register
     class PythonErrorOnInvoke(enact.Invokable):
-      def call(self, unused_input: enact.ResourceBase):
+      def call(self, unused_input: int):
         raise ValueErrorResource('foo')
+    @enact.register
     class ExpectValueError(enact.Invokable):
-      def call(self, unused_input: enact.ResourceBase):
+      def call(self, unused_input: int):
         try:
           PythonErrorOnInvoke()(3)
         except ValueErrorResource:
@@ -284,14 +288,16 @@ class InvocationsTest(unittest.TestCase):
 
   def test_raised_here(self):
     """Tests that the raised_here field is set correctly."""
+    @enact.register
     class PythonErrorOnInvoke(enact.Invokable):
-      def call(self, unused_input: enact.ResourceBase):
+      def call(self, unused_input: int):
         raise ValueErrorResource('foo')
 
+    @enact.register
     @dataclasses.dataclass
     class SubCall(enact.Invokable):
       invokable: enact.Ref[enact.InvokableBase]
-      def call(self, input_resource: enact.ResourceBase):
+      def call(self, input_resource: int):
         self.invokable.checkout()(input_resource)
 
     with self.store as store:
@@ -521,6 +527,7 @@ class InvocationsTest(unittest.TestCase):
 
   def test_request_input_fun(self):
     """Tests the request_input function."""
+    @enact.register
     class MyInvokable(enact.Invokable):
       def call(self, value: int):
         return enact.request_input(int) + value
@@ -722,6 +729,7 @@ class AsyncInvocationsTest(unittest.TestCase):
 
   def test_wrapped_resource_async(self):
     """Tests that exceptions are tracked as wrapped when enabled."""
+    @enact.register
     class PythonErrorOnInvoke(enact.AsyncInvokable):
       async def call(self, unused_input: enact.ResourceBase):
         raise ValueError('foo')

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -132,7 +132,8 @@ class StoreTest(unittest.IsolatedAsyncioTestCase):
   def _as_async(self, fun: Callable[..., T]) -> (
       Callable[..., Awaitable[T]]):
     """Returns either the sync or corresponding async function."""
-    assert getattr(fun, '__self__'), 'Callable must be a bound instance method.'
+    assert getattr(fun, '__self__') is not None, (
+      'Callable must be a bound instance method.')
     if not self._async:
       async def wrapper(*args, **kwargs):
         return fun(*args, **kwargs)

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -73,7 +73,8 @@ class JsonPackedRef(enact.Ref):
       JsonPackedResource(serialization.JsonSerializer().serialize(
         resource.to_resource_dict())).to_resource_dict(),
       ref_dict=ref.to_resource_dict(),
-      links={})
+      links=set(),
+      type_keys=set())
 
 
 class RefTest(unittest.TestCase):

--- a/tests/test_resource_registry.py
+++ b/tests/test_resource_registry.py
@@ -76,7 +76,7 @@ class RegistryTest(unittest.TestCase):
   def test_lookup_error(self):
     """Tests that lookup raises the correct error."""
     registry = enact.Registry()
-    with self.assertRaises(enact.ResourceNotFound):
+    with self.assertRaises(enact.UnregisteredResource):
       registry.lookup('SimpleResource')
 
   def test_singleton_and_decorator(self):


### PR DESCRIPTION
Enact stores type descriptors in the backend so that the structure of a resource can be interpreted without having the associated python class loaded. For example, a resource `SimpleResource(x=1, y=2.0)` (with `x` typed as `int` and `y` as `float`) would have a type descriptor `{'x': enact.types.Int(), 'y': enact.types.Float()}`.

Previously there was a bug which would lead to nested resources not having their type stored. This fixes the bug.